### PR TITLE
Hacky fix for nametags

### DIFF
--- a/src/main/java/com/mrlolethan/stackedmobs/util/StacksUtil.java
+++ b/src/main/java/com/mrlolethan/stackedmobs/util/StacksUtil.java
@@ -8,7 +8,9 @@ import com.mrlolethan.stackedmobs.P;
 public enum StacksUtil {;
 
 	/** The stacked mob custom name format. */
-	public static String CUSTOM_NAME_FORMAT = "x%1$d";
+
+	//Set default name format to include special color code and special unicode X.
+	public static String CUSTOM_NAME_FORMAT = "\u00A76Χ%1$d";
 	public static int INVALID_STACK = -1;
 
 
@@ -77,6 +79,7 @@ public enum StacksUtil {;
 		if (displayName == null) {
 			return INVALID_STACK; // No display name, therefor not a stack.
 		}
+				
 		// Fetch the stack number color
 		ChatColor stackNumberColor = P.getInstance().getConfiguration().stackNumberColor;
 
@@ -84,8 +87,22 @@ public enum StacksUtil {;
 		if (nameColor.equals(ChatColor.COLOR_CHAR + stackNumberColor.getChar())) {
 			return INVALID_STACK; // Not a valid stack.
 		}
-		String cleanDisplayName = ChatColor.stripColor(displayName).replace("x", "");
-		return Integer.parseInt(cleanDisplayName);
+				
+		//Sterilize mob displayname.. 
+		//Not possible to set this via nametag. Nametag results would be "&6X99" or something like "\u00A7f\u00A76X99"
+		String cleanDisplayName = displayName.replace("\u00A76Χ", "");
+		String cleanDisplayName2 = cleanDisplayName.replace("§f", "");
+
+		//Check if sterilized thing is valid by checking if it just a number or if number is unrealistically large.
+		if (cleanDisplayName2.matches("[0-9]+") == false){
+			//P.log(Level.WARNING, "Match char: " + cleanDisplayName2);
+			return INVALID_STACK;
+		}else if (cleanDisplayName2.length() > 4 == true){
+			//P.log(Level.WARNING, "Match len: " + cleanDisplayName2);
+			return INVALID_STACK;
+		}else{
+			return Integer.parseInt(cleanDisplayName2);
+		}
 	}
 
 	public static boolean isStacked(LivingEntity entity) {


### PR DESCRIPTION
Could rename a mob to "x99" to get 99 of said mob.

This fix should do the trick.. Couldn't get around my own fix even with color
codes and special X's.

(Note, I have minimal knowledge of Java, but it seems to work quite well.)
